### PR TITLE
added default 'no' values to some notes fields

### DIFF
--- a/src/components/notes/noteFields/FamilySuicide.js
+++ b/src/components/notes/noteFields/FamilySuicide.js
@@ -10,8 +10,10 @@ export const FamilySuicide = () => {
   };
 
   useEffect(() => {
-    if (!familySuicide) {
+    if (typeof familySuicide === "undefined") {
       setFamilySuicideNotes("");
+    } else if (!familySuicide) {
+      setFamilySuicideNotes("Denies any family history of suicide.");
     }
   }, [familySuicide]);
 

--- a/src/components/notes/noteFields/HeadInjury.js
+++ b/src/components/notes/noteFields/HeadInjury.js
@@ -10,8 +10,12 @@ export const HeadInjury = () => {
   };
 
   useEffect(() => {
-    if (!headInjury) {
+    if (typeof headInjury === "undefined") {
       setHeadInjuryNotes("");
+    } else if (!headInjury) {
+      setHeadInjuryNotes(
+        "Denies any history of seizures, serious head injuries/TBIs."
+      );
     }
   }, [headInjury]);
 

--- a/src/components/notes/noteFields/Trauma.js
+++ b/src/components/notes/noteFields/Trauma.js
@@ -10,8 +10,12 @@ export const Trauma = () => {
   };
 
   useEffect(() => {
-    if (!trauma) {
+    if (typeof trauma === "undefined") {
       setTraumaNotes("");
+    } else if (!trauma) {
+      setTraumaNotes(
+        "Denies any hx of physical, sexual, and/or emotional/psychological abuse."
+      );
     }
   }, [trauma]);
 


### PR DESCRIPTION
* checks if the value of the radio buttons is `undefined`, will leave notes blank (helpful for page render especially)
* otherwise added default text if the option selected is 'no'
* added to `Trauma.js`, `HeadInjury.js`, `FamilySuicide.js`
* will allow for cleaner handling of attaching 'notes' fields to the actual note
* closes #19
* progresses #7