### PR TITLE
fixed fetch calls for expanding visitType

### DIFF
--- a/src/components/notes/CompletedNote.js
+++ b/src/components/notes/CompletedNote.js
@@ -8,7 +8,7 @@ export const CompletedNote = () => {
   const [noteSymptoms, setNoteSymptoms] = useState([]);
   const [noteSubstances, setSubstances] = useState([]);
 
-  let { noteId } = useParams();
+  let { date, noteId } = useParams();
   noteId = parseInt(noteId);
 
   useEffect(() => {
@@ -39,7 +39,8 @@ export const CompletedNote = () => {
       <section className="complete-note preamble">
         <div>
           {/* TODO add seen for {visitType} - but showing up undefined for some reason */}
-          Patient is a {note.patientAge} y/o {note.patientGender}.
+          Patient is a {note.patientAge} y/o {note.patientGender} seen for{" "}
+          {note.visitType?.type}.
         </div>
         <div>Chief Complaint: "{note.chiefComplaint}"</div>
       </section>

--- a/src/components/notes/NoteList.js
+++ b/src/components/notes/NoteList.js
@@ -8,7 +8,7 @@ export const NoteList = () => {
   const { date } = useParams();
 
   useEffect(() => {
-    fetch(`${API}/notes?visitDate=${date}&_expand=visitType&_sort=visitTime`)
+    fetch(`${API}/notes?visitDate=${date}&_expand=visitType`)
       .then((res) => res.json())
       .then((notesArray) => {
         setNotes(notesArray);
@@ -25,7 +25,8 @@ export const NoteList = () => {
               to={`/dates/${date}/${note.id}`}
             >
               {/* TODO FIXME why is note.visitType.type undefined ? */}
-              {note.patientAge} {note.patientGender} @ {note.visitTime}
+              {note.patientAge} {note.patientGender} @ {note.visitTime} (
+              {note.visitType.type})
             </Link>
           </li>
         );


### PR DESCRIPTION
* issue was poor understanding of url path vs. queries
* now, hitting API @ a note primary key, expanding other Ids
* visitType is now displaying everywhere I'm expecting it to (DateList, NoteList)
* closes #71 